### PR TITLE
Fix RequestDependencyWarning updating requests package to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ gunicorn==19.7
 psycopg2==2.7.3.1
 SQLAlchemy==1.2.0b2
 urllib3==1.24.2
-requests==2.18.4
+requests==2.24.0
 gevent==1.4.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,7 +14,7 @@ psycopg2==2.7.3.1
 Pygments==2.2.0
 python-mimeparse==1.6.0
 pytz==2017.2
-requests==2.18.4
+requests==2.24.0
 six==1.11.0
 snowballstemmer==1.2.1
 Sphinx==1.6.4


### PR DESCRIPTION
Sometimes was thrown an exception like this:

```
2020-07-19 23:58:55,188 - mconf_aggr.webhook.database_handler      -     INFO - Processing information to database took 0.0087s.
[2020-07-20 00:01:35 +0000] [1] [CRITICAL] WORKER TIMEOUT (pid:7)
[2020-07-20 00:01:41 +0000] [12] [INFO] Booting worker with pid: 12
[2020-07-20 00:02:11 +0000] [1] [CRITICAL] WORKER TIMEOUT (pid:12)
[2020-07-20 00:02:12 +0000] [13] [INFO] Booting worker with pid: 13
2020-07-20 00:02:21,801 - mconf_aggr.aggregator.aggregator         -     INFO - Aggregator created.
2020-07-20 00:02:21,895 - mconf_aggr.aggregator.aggregator         -     INFO - Setting up aggregator.
2020-07-20 00:02:21,895 - mconf_aggr.webhook.database_handler      -     INFO - Setting up WebhookDataWriter
2020-07-20 00:02:21,896 - mconf_aggr.aggregator.aggregator         -     INFO - Starting threads for callbacks.
2020-07-20 00:02:21,897 - mconf_aggr.aggregator.aggregator         -     INFO - All threads started with success.
2020-07-20 00:02:21,897 - mconf_aggr.aggregator.aggregator         -     INFO - Aggregator running.
[2020-07-20 00:02:23 +0000] [1] [INFO] Handling signal: term
2020-07-20 00:02:23,413 - mconf_aggr.webhook.event_listener        -     INFO - Webhook event received from 'live-do066.elos.vc' (last hop: 'webhook-lb.elos.vc').
2020-07-20 00:02:23,417 - mconf_aggr.webhook.event_listener        -     INFO - Webhook event received from 'live-do066.elos.vc' (last hop: 'webhook-lb.elos.vc').
2020-07-20 00:02:23,435 - mconf_aggr.webhook.database_handler      -     INFO - Processing rap-publish-started event for internal-meeting-id '28d27942765efe098bf5e6a5b7c1ae7981c374da-1595201578364'.
2020-07-20 00:02:23,453 - mconf_aggr.webhook.database_handler      -     INFO - Processing information to database took 0.018s.
2020-07-20 00:02:23,454 - mconf_aggr.webhook.database_handler      -     INFO - Processing rap-post-publish-started event for internal-meeting-id '28d27942765efe098bf5e6a5b7c1ae7981c374da-1595201578364'.
2020-07-20 00:02:23,466 - mconf_aggr.webhook.database_handler      -     INFO - Processing information to database took 0.0128s.
/usr/local/lib/python3.6/site-packages/requests/__init__.py:80: RequestsDependencyWarning: urllib3 (1.24.2) or chardet (3.0.4) doesn't match a supported version!
  RequestsDependencyWarning)
[2020-07-20 00:02:27 +0000] [13] [INFO] Worker exiting (pid: 13)
Exception ignored in: <module 'threading' from '/usr/local/lib/python3.6/threading.py'>
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/threading.py", line 1294, in _shutdown
    t.join()
  File "/usr/local/lib/python3.6/site-packages/gevent/threading.py", line 189, in join
    self._greenlet.join(timeout=timeout)
  File "src/gevent/greenlet.py", line 711, in gevent._greenlet.Greenlet.join
  File "src/gevent/greenlet.py", line 737, in gevent._greenlet.Greenlet.join
  File "src/gevent/greenlet.py", line 726, in gevent._greenlet.Greenlet.join
  File "src/gevent/_greenlet_primitives.py", line 60, in gevent.__greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 64, in gevent.__greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/__greenlet_primitives.pxd", line 35, in gevent.__greenlet_primitives._greenlet_switch
gevent.exceptions.LoopExit: This operation would block forever
        Hub: <Hub '' at 0x7f062aac5e10 epoll default pending=0 ref=0 fileno=7 thread_ident=0x7f062bc99b68>
        Handles:
[]
[2020-07-20 00:02:27 +0000] [1] [INFO] Shutting down: Master
```

Updating requests to latest version fixes it 'cause they fixed it in 2.19 (https://github.com/psf/requests/issues/4673).