### PR TITLE
Fill recordings with data from meetings_events, update documentation and foreign keys 

### DIFF
--- a/mconf_aggr/webhook/database_handler.py
+++ b/mconf_aggr/webhook/database_handler.py
@@ -669,9 +669,11 @@ class RapArchiveHandler(DatabaseEventHandler):
                 records_table.end_time = meetings_events_table.end_time
                 records_table.r_shared_secret_guid = meetings_events_table.shared_secret_guid
                 records_table.r_institution_guid = meetings_events_table.institution_guid
+                records_table.external_meeting_id = meetings_events_table.external_meeting_id
+                records_table.internal_meeting_id = meetings_events_table.internal_meeting_id
             else:
                 logging_extra["code"] = "Meeting not found",
-                logging_extra["keywords"]=  ["meeting not found", "warning", "event handler", "database", f"internal-meeting-id={event.internal_meeting_id}"]
+                logging_extra["keywords"]=  ["meeting not found", "warning", "event handler", "database", f"internal-meeting-id={event.internal_meeting_id}", f"data={event}"]
 
                 self.logger.warn(f"No meeting found for recording '{event.record_id}'.", extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"])))
 
@@ -762,6 +764,8 @@ class RapHandler(DatabaseEventHandler):
             records_table.end_time = meetings_events_table.end_time
             records_table.r_shared_secret_guid = meetings_events_table.shared_secret_guid
             records_table.r_institution_guid = meetings_events_table.institution_guid
+            records_table.external_meeting_id = meetings_events_table.external_meeting_id
+            records_table.internal_meeting_id = meetings_events_table.internal_meeting_id
         else:
             logging_extra["code"] = "Meeting not found"
             logging_extra["keywords"] = ["meeting not found", "warning", "event handler", "database", f"record={event.record_id}", f"internal-meeting-id={event.internal_meeting_id}"]

--- a/mconf_aggr/webhook/database_handler.py
+++ b/mconf_aggr/webhook/database_handler.py
@@ -768,7 +768,7 @@ class RapHandler(DatabaseEventHandler):
             records_table.internal_meeting_id = meetings_events_table.internal_meeting_id
         else:
             logging_extra["code"] = "Meeting not found"
-            logging_extra["keywords"] = ["meeting not found", "warning", "event handler", "database", f"record={event.record_id}", f"internal-meeting-id={event.internal_meeting_id}"]
+            logging_extra["keywords"] = ["meeting not found", "warning", "event handler", "database", f"record={event.record_id}", f"internal-meeting-id={event.internal_meeting_id}", f"data={event}"]
             self.logger.warn(f"No meeting found for recording '{event.record_id}'.", extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"])))
 
         records_table.current_step = event.current_step

--- a/mconf_aggr/webhook/database_model.py
+++ b/mconf_aggr/webhook/database_model.py
@@ -91,8 +91,6 @@ class Meetings(Base):
     meeting_event_id = Column(Integer, ForeignKey("meetings_events.id"))
     meeting_event = relationship("MeetingsEvents")
 
-    #meeting_event = relationship("MeetingsEvents", backref=backref("meetings", uselist=False))
-
     created_at = Column(DateTime, default=datetime.datetime.now)
     updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
@@ -344,8 +342,8 @@ class Recordings(Base):
     updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
     record_id = Column(String(255), unique=True)
-    meeting_event_id = Column(Integer)
-    server_id = Column(Integer)
+    meeting_event_id = Column(Integer, ForeignKey("meetings_events.id"))
+    server_id = Column(Integer, ForeignKey("servers.id"))
 
     name = Column(String(255))
     status = Column(status_enum)
@@ -382,6 +380,7 @@ class Recordings(Base):
             + ", created_at=" + str(self.created_at)
             + ", updated_at=" + str(self.updated_at)
             + ", record_id=" + str(self.record_id)
+            + ", meeting_event_id=" + str(self.meeting_event_id)
             + ", server_id=" + str(self.server_id)
             + ", name=" + str(self.name)
             + ", status=" + str(self.status)
@@ -441,8 +440,6 @@ class UsersEvents(Base):
     meeting_event_id = Column(Integer, ForeignKey("meetings_events.id"))
     meeting_event = relationship("MeetingsEvents")
 
-    #meeting_event = relationship("MeetingsEvents", backref=backref("users_events", uselist=False))
-
     created_at = Column(DateTime, default=datetime.datetime.now)
     updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
 
@@ -501,7 +498,7 @@ class Servers(Base):
 
     id = Column(Integer, primary_key=True)
     guid = Column(String, unique=True)
-    institution_guid = Column(String, unique=True)
+    institution_guid = Column(String, ForeignKey("institutions.guid"), unique=True)
     name = Column(String(50))
     secret = Column(String(50))
     ip = Column(String(15))
@@ -554,7 +551,7 @@ class SharedSecrets(Base):
 
     id = Column(Integer, primary_key=True)
     guid = Column(String, unique=True)
-    institution_guid = Column(String, unique=True)
+    institution_guid = Column(String, ForeignKey("institutions.guid"), unique=True)
     name = Column(String)
     secret = Column(String)
     scope = Column(String)

--- a/mconf_aggr/webhook/event_mapper.py
+++ b/mconf_aggr/webhook/event_mapper.py
@@ -423,6 +423,8 @@ def _map_rap_publish_ended_event(event, event_type, server_url):
 
 
 def _map_rap_archive_event(event, event_type, server_url):
+    """Map `rap-archive-*` event to internal representation.
+    """
     rap_event = RapArchiveEvent(
                     external_meeting_id=_get_nested(event, ["data", "attributes", "meeting", "external-meeting-id"], ""),
                     internal_meeting_id=_get_nested(event, ["data", "attributes", "meeting", "internal-meeting-id"], ""),


### PR DESCRIPTION
When a rap event does not send `external_meeting_id` the recording will have `NULL` in this field. To fix this, rap events will fill this field based on a query on `meeting_events`. If you cannot find this meeting, log each field for this event.