### PR TITLE
Rename metadata column of users_events to userdata

### DIFF
--- a/mconf_aggr/webhook/database_handler.py
+++ b/mconf_aggr/webhook/database_handler.py
@@ -313,7 +313,8 @@ class UserJoinedHandler(DatabaseEventHandler):
             "is_presenter" : event.is_presenter,
             "is_listening_only" : False,
             "has_joined_voice" : False,
-            "has_video" : False
+            "has_video" : False,
+            "user_data" : event.userdata
         }
 
         # Query for meetings_events to link with users_events table.

--- a/mconf_aggr/webhook/database_model.py
+++ b/mconf_aggr/webhook/database_model.py
@@ -431,7 +431,7 @@ class UsersEvents(Base):
         Internal user ID of the user.
     external_user_id : Column of type String
         External user ID of the user.
-    metadata : Column of type JSON
+    userdata : Column of type JSON
         Information about the user metadata.
     """
     __tablename__ = "users_events"
@@ -450,7 +450,7 @@ class UsersEvents(Base):
     internal_user_id = Column(String(255), unique=True)
     external_user_id = Column(String(255))
 
-    meta_data = Column("metadata", JSON) # Name metadata is used by Base class.
+    userdata = Column("userdata", JSON)
 
     @validates('name')
     def validate_code(self, key, value):
@@ -471,7 +471,7 @@ class UsersEvents(Base):
                 + ", leave_time=" + str(self.leave_time)
                 + ", internal_user_id=" + str(self.internal_user_id)
                 + ", external_user_id=" + str(self.external_user_id)
-                + ", meta_data=" + str(self.meta_data)
+                + ", userdata=" + str(self.userdata)
                 + ")>")
 
 

--- a/mconf_aggr/webhook/event_mapper.py
+++ b/mconf_aggr/webhook/event_mapper.py
@@ -54,7 +54,7 @@ UserJoinedEvent = collections.namedtuple('UserJoinedEvent',
                                                 'external_meeting_id',
                                                 'join_time',
                                                 'is_presenter',
-                                                'meta_data'
+                                                'userdata'
                                          ])
 
 
@@ -65,7 +65,7 @@ UserLeftEvent = collections.namedtuple('UserLeftEvent',
                                                 'internal_meeting_id',
                                                 'external_meeting_id',
                                                 'leave_time',
-                                                'meta_data'
+                                                'userdata'
                                        ])
 
 UserVoiceEnabledEvent = collections.namedtuple('UserVoiceEnabledEvent',
@@ -317,7 +317,7 @@ def _map_user_joined_event(event, event_type, server_url):
                      external_meeting_id=_get_nested(event, ["data", "attributes", "meeting", "external-meeting-id"], ""),
                      join_time=_get_nested(event, ["data", "event", "ts"], ""),
                      is_presenter=_get_nested(event, ["data", "attributes", "user", "presenter"], True),
-                     meta_data=_get_nested(event, ["data", "attributes", "user", "metadata"], {}))
+                     userdata=_get_nested(event, ["data", "attributes", "user", "userdata"], {}))
 
     webhook_event = WebhookEvent(event_type, user_event, server_url)
 
@@ -332,7 +332,7 @@ def _map_user_left_event(event, event_type, server_url):
                      internal_meeting_id=_get_nested(event, ["data", "attributes", "meeting", "internal-meeting-id"], ""),
                      external_meeting_id=_get_nested(event, ["data", "attributes", "meeting", "external-meeting-id"], ""),
                      leave_time=_get_nested(event, ["data", "event", "ts"], ""),
-                     meta_data=_get_nested(event, ["data", "attributes", "user", "metadata"], {}))
+                     userdata=_get_nested(event, ["data", "attributes", "user", "userdata"], {}))
 
     webhook_event = WebhookEvent(event_type, user_event, server_url)
 


### PR DESCRIPTION
`user-joined` or `user-left` events can have a `userdata` field with some information. This update modifies the model of the table `users_events`, renaming the column `metadata` to `userdata` and adding this information to the entry in these two events.