### PR TITLE
Configure /health and /ready

### DIFF
--- a/mconf_aggr/webhook/probe_listener.py
+++ b/mconf_aggr/webhook/probe_listener.py
@@ -75,11 +75,6 @@ class LivenessProbeListener(ProbeListener):
         -------
         bool : True if the application is running correctly. False otherwise.
         """
-        logging_extra = {
-            "code": "Endpoint listener",
-            "site": "LivenessProbeListener._ok",
-            "keywords": ["listener", "endpoint", "health"]
-        }
 
         return True
 

--- a/mconf_aggr/webhook/probe_listener.py
+++ b/mconf_aggr/webhook/probe_listener.py
@@ -55,7 +55,7 @@ class ProbeListener:
             resp.body = "OK"
             resp.status = falcon.HTTP_200 # OK.
         else:
-            resp.body = ""
+            resp.body = "NOT OK"
             resp.status = falcon.HTTP_503 # Service unavailable.
 
     def _ok(self):
@@ -81,13 +81,6 @@ class LivenessProbeListener(ProbeListener):
             "keywords": ["listener", "endpoint", "health"]
         }
 
-        try:
-            _ping_database()
-        except DatabaseNotReadyError as err:
-            self.logger.warn(str(err), extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"])))
-
-            return False
-
         return True
 
 
@@ -96,7 +89,7 @@ class ReadinessProbeListener(ProbeListener):
     """
 
     def _ok(self):
-        """Implements endpoint-specific logic of /health.
+        """Implements endpoint-specific logic of /ready.
 
         Returns
         -------


### PR DESCRIPTION
The /ready route was already configured as it should be, pinging the database. However, the /health route had the exact same behaviour. Now, it just returns an "OK" if the server is up.