### PR TITLE
Added logging for raw/unprocessed requests

### DIFF
--- a/mconf_aggr/webhook/event_listener.py
+++ b/mconf_aggr/webhook/event_listener.py
@@ -71,7 +71,7 @@ class AuthMiddleware:
             "keywords": ["https", "falcon", "requests", "domain"]
         }
 
-        self.logger.info("Received request with body: '{}'".format(req.get_param("event")), extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"])))
+        self.logger.info("Received '{}'".format(req) + " request with body: '{}'".format(req.get_param("event")), extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"])))
 
         auth_required = cfg.config["MCONF_WEBHOOK_AUTH_REQUIRED"]
 

--- a/mconf_aggr/webhook/event_listener.py
+++ b/mconf_aggr/webhook/event_listener.py
@@ -71,7 +71,7 @@ class AuthMiddleware:
             "keywords": ["https", "falcon", "requests", "domain"]
         }
 
-        self.logger.info("Received '{}'".format(req) + " request with event: '{}'".format(req.get_param("event")), extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"])))
+        self.logger.info(f"Received request: '{req.params}'", extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"])))
 
         auth_required = cfg.config["MCONF_WEBHOOK_AUTH_REQUIRED"]
 

--- a/mconf_aggr/webhook/event_listener.py
+++ b/mconf_aggr/webhook/event_listener.py
@@ -71,7 +71,7 @@ class AuthMiddleware:
             "keywords": ["https", "falcon", "requests", "domain"]
         }
 
-        self.logger.info("Received '{}'".format(req) + " request with body: '{}'".format(req.get_param("event")), extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"])))
+        self.logger.info("Received '{}'".format(req) + " request with event: '{}'".format(req.get_param("event")), extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"])))
 
         auth_required = cfg.config["MCONF_WEBHOOK_AUTH_REQUIRED"]
 

--- a/mconf_aggr/webhook/event_listener.py
+++ b/mconf_aggr/webhook/event_listener.py
@@ -71,6 +71,8 @@ class AuthMiddleware:
             "keywords": ["https", "falcon", "requests", "domain"]
         }
 
+        self.logger.info("Received request with body: '{}'".format(req.get_param("event")), extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"])))
+
         auth_required = cfg.config["MCONF_WEBHOOK_AUTH_REQUIRED"]
 
         if auth_required:


### PR DESCRIPTION
Info was added to log raw requests before authentication and processing.

If the request log's format is considered too "bloated" due to the sheer size of the body, or if anything else needs to be removed/added, please inform me bellow and I will re-structure it ASAP.