### PR TITLE
Fixed deprecated uses of Falcon library

### DIFF
--- a/mconf_aggr/webhook/event_listener.py
+++ b/mconf_aggr/webhook/event_listener.py
@@ -86,8 +86,8 @@ class AuthMiddleware:
                     extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"]))
                 )
                 raise falcon.HTTPUnauthorized(
-                    "Domain required for authentication",
-                    "Provide a valid domain as part of the request"
+                    title="Domain required for authentication",
+                    description="Provide a valid domain as part of the request"
                 )
 
             server_url = _normalize_server_url(server_url)
@@ -103,9 +103,9 @@ class AuthMiddleware:
                     extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"]))
                 )
                 raise falcon.HTTPUnauthorized(
-                    "Authentication required",
-                    "Provide an authentication token as part of the request",
-                    www_authentication
+                    title="Authentication required",
+                    description="Provide an authentication token as part of the request",
+                    headers=www_authentication
                 )
 
             if not self._token_is_valid(server_url, token):
@@ -117,9 +117,9 @@ class AuthMiddleware:
                     extra=dict(logging_extra, keywords=json.dumps(logging_extra["keywords"]))
                 )
                 raise falcon.HTTPUnauthorized(
-                    "Unable to validate authentication token",
-                    "The provided authentication token could not be validate",
-                    www_authentication
+                    title="Unable to validate authentication token",
+                    description="The provided authentication token could not be validate",
+                    headers=www_authentication
                 )
 
     def _token_is_valid(self, host, token, handler=None):

--- a/mconf_aggr/webhook/probe_listener.py
+++ b/mconf_aggr/webhook/probe_listener.py
@@ -52,10 +52,10 @@ class ProbeListener:
         resp : falcon.Response
         """
         if (self._ok()):
-            resp.body = "OK"
+            resp.text = "OK"
             resp.status = falcon.HTTP_200 # OK.
         else:
-            resp.body = "NOT OK"
+            resp.text = "NOT OK"
             resp.status = falcon.HTTP_503 # Service unavailable.
 
     def _ok(self):


### PR DESCRIPTION
Changes made:

1) falcon.HTTPUnauthorized method updated. Calls with positional arguments are deprecated. Specified them as keyword arguments instead;

2) falcon.response.body property replaced. **Body** is a deprecated alias for **text**.