### PR TITLE
Added monkey.patch_all to try to fix shutdown bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3.6
 
+import gevent
+gevent.monkey.patch_all()
+
 import json
 import logging
 import time
@@ -9,7 +12,6 @@ import os
 import signal
 
 import falcon
-import gevent
 
 import mconf_aggr.aggregator.cfg as cfg
 from mconf_aggr.webhook.database import DatabaseConnector


### PR DESCRIPTION
# Description

After updating the Python version from 3.6 to 3.9, a new error started happening when the application received a SIGTERM signal during shutdown. This aims to fix the problem.

## How to

As the bug is seemingly very hard to replicate locally, a docker image titled `c605df`, the first 6 digits of the fix's commit hash, was uploaded to dockerhub and deployed into the homologation enviroment, it seems to have fixed the problem as seen in `Grafana's` logs.