### PR TITLE
Update recording metadata

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@ COMPOSE_PROJECT_NAME=production
 MCONF_AGGR_WEBHOOK_ENV_FILE=./envs/webhook-env-file.env
 
 PYTHON_VERSION=3.9.10
-POETRY_VERSION=1.1.13
+POETRY_VERSION=1.3.2
 # Poetry inside dir (inside container)
 POETRY_HOME=/opt/poetry
 POETRY_VIRTUALENVS_CREATE=false

--- a/mconf_aggr/webhook/database_handler.py
+++ b/mconf_aggr/webhook/database_handler.py
@@ -1392,6 +1392,8 @@ class RapPublishHandler(DatabaseEventHandler):
                 # overwriting currently saved meta_data.
                 if records_table.meta_data:
                     event.meta_data.update(records_table.meta_data)
+                if event.workflow == "presentation":
+                    event.meta_data.update({"mconf-decrypter-pending": "false"})
                 records_table.meta_data = event.meta_data
                 records_table.download = event.download
                 records_table.current_step = event.current_step

--- a/tests/black-box/post_event.py
+++ b/tests/black-box/post_event.py
@@ -2,7 +2,7 @@ import getopt
 import json
 import sys
 
-from Utility.utils import post_event
+from utility.utils import post_event
 
 
 def main(argv):


### PR DESCRIPTION
### Recordings with the `mconf-decrypter-pending=true` metadata are unnecessarily returned in the `/getRecordings` response, compromising the server's response.

### The purpose of this PR is to set this metadata to `false` once the `workflow` field has updated the value of `presentation` to `published`.