### PR TITLE
Set users leave_time when meeting ends

### DIFF
--- a/mconf_aggr/webhook/database_handler.py
+++ b/mconf_aggr/webhook/database_handler.py
@@ -232,7 +232,7 @@ class MeetingEndedHandler(DatabaseEventHandler):
                 self.session.query(UsersEvents)
                 .filter(
                     UsersEvents.meeting_event_id == meetings_events_table.id,
-                    UsersEvents.leave_time is None,
+                    UsersEvents.leave_time == None,
                 )
                 .update({"leave_time": event.end_time}, synchronize_session="fetch")
             )


### PR DESCRIPTION
This PR aims to set the `leave_time` of users in the database when a meeting is forcibly terminated.

This behavior was already implemented, but it contained a configuration error, which this PR corrects.